### PR TITLE
Add time since last weather update to weather app

### DIFF
--- a/src/displayapp/screens/Weather.cpp
+++ b/src/displayapp/screens/Weather.cpp
@@ -49,7 +49,7 @@ Weather::Weather(Controllers::Settings& settingsController,
 
   lastUpdated = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lastUpdated, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::bg);
-  lv_label_set_text_fmt(lastUpdated, "");
+  lv_label_set_text(lastUpdated, "");
 
   minTemperature = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(minTemperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::bg);
@@ -150,20 +150,30 @@ void Weather::Refresh() {
       int8_t minutesSinceWeatherUpdate = secondsSinceWeatherUpdate / 60;
       int8_t hoursSinceWeatherUpdate = secondsSinceWeatherUpdate / 3600;
 
-      lv_obj_align(lastUpdated, nullptr, LV_ALIGN_CENTER, -31, -1);
-      if ((secondsSinceWeatherUpdate > 9 && secondsSinceWeatherUpdate < 60) ||
-          (minutesSinceWeatherUpdate > 9 && minutesSinceWeatherUpdate < 60) || hoursSinceWeatherUpdate > 9) {
-        lv_obj_align(lastUpdated, nullptr, LV_ALIGN_CENTER, -41, -1);
-      }
+      constexpr uint8_t Y_POSITION = 108;
+      constexpr uint8_t X_SINGLE_DIGIT_POSITION = 90;
+      constexpr uint8_t X_TWO_DIGIT_POSITION = 78;
+      constexpr uint8_t X_NOW_POSITION = 102;
+
+      lv_obj_set_pos(lastUpdated, X_SINGLE_DIGIT_POSITION, Y_POSITION);
 
       if (hoursSinceWeatherUpdate > 0) {
+        if (hoursSinceWeatherUpdate > 9) {
+          lv_obj_set_pos(lastUpdated, X_TWO_DIGIT_POSITION, Y_POSITION);
+        }
         lv_label_set_text_fmt(lastUpdated, "%dh ago", hoursSinceWeatherUpdate);
       } else if (minutesSinceWeatherUpdate > 0) {
+        if (minutesSinceWeatherUpdate > 9 && minutesSinceWeatherUpdate < 60) {
+          lv_obj_set_pos(lastUpdated, X_TWO_DIGIT_POSITION, Y_POSITION);
+        }
         lv_label_set_text_fmt(lastUpdated, "%dm ago", minutesSinceWeatherUpdate);
       } else if (secondsSinceWeatherUpdate > 30) {
+        if (secondsSinceWeatherUpdate > 9 && secondsSinceWeatherUpdate < 60) {
+          lv_obj_set_pos(lastUpdated, X_TWO_DIGIT_POSITION, Y_POSITION);
+        }
         lv_label_set_text_fmt(lastUpdated, "%ds ago", secondsSinceWeatherUpdate);
       } else if (secondsSinceWeatherUpdate < 31) {
-        lv_obj_align(lastUpdated, nullptr, LV_ALIGN_CENTER, -18, -1);
+        lv_obj_set_pos(lastUpdated, X_NOW_POSITION, Y_POSITION);
         lv_label_set_text_fmt(lastUpdated, "Now", secondsSinceWeatherUpdate);
       }
     } else {

--- a/src/displayapp/screens/Weather.cpp
+++ b/src/displayapp/screens/Weather.cpp
@@ -44,13 +44,13 @@ Weather::Weather(Controllers::Settings& settingsController,
   lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_text_font(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
   lv_label_set_text(temperature, "---");
-  lv_obj_align(temperature, nullptr, LV_ALIGN_CENTER, 0, -30);
+  lv_obj_align(temperature, nullptr, LV_ALIGN_CENTER, 0, -32);
   lv_obj_set_auto_realign(temperature, true);
 
   lastUpdated = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lastUpdated, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::bg);
   lv_label_set_text_fmt(lastUpdated, "");
-  lv_obj_align(lastUpdated, nullptr, LV_ALIGN_CENTER, -40, 0);
+  lv_obj_align(lastUpdated, nullptr, LV_ALIGN_CENTER, -40, -1);
 
   minTemperature = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(minTemperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::bg);
@@ -148,13 +148,13 @@ void Weather::Refresh() {
       int64_t secondsSinceEpoch = dateTimeController.CurrentDateTime().time_since_epoch().count() / 1000000000;
       int64_t secondsSinceWeatherUpdate = secondsSinceEpoch - optCurrentWeather->timestamp;
       if (secondsSinceWeatherUpdate < 0) {
-        lv_label_set_text_fmt(lastUpdated, "0s old", secondsSinceWeatherUpdate);
+        lv_label_set_text_fmt(lastUpdated, "0s ago", secondsSinceWeatherUpdate);
       } else if (secondsSinceWeatherUpdate < 60) {
-        lv_label_set_text_fmt(lastUpdated, "%ds old", secondsSinceWeatherUpdate);
+        lv_label_set_text_fmt(lastUpdated, "%ds ago", secondsSinceWeatherUpdate);
       } else if (secondsSinceWeatherUpdate > 59 && secondsSinceWeatherUpdate < 3600) {
-        lv_label_set_text_fmt(lastUpdated, "%dm old", secondsSinceWeatherUpdate / 60);
+        lv_label_set_text_fmt(lastUpdated, "%dm ago", secondsSinceWeatherUpdate / 60);
       } else if (secondsSinceWeatherUpdate > 3599) {
-        lv_label_set_text_fmt(lastUpdated, "%dh old", secondsSinceWeatherUpdate / 3600);
+        lv_label_set_text_fmt(lastUpdated, "%dh ago", secondsSinceWeatherUpdate / 3600);
       }
     } else {
       lv_label_set_text(icon, "");

--- a/src/displayapp/screens/Weather.h
+++ b/src/displayapp/screens/Weather.h
@@ -4,6 +4,7 @@
 #include <lvgl/lvgl.h>
 #include "displayapp/screens/Screen.h"
 #include "components/ble/SimpleWeatherService.h"
+#include "components/datetime/DateTimeController.h"
 #include "displayapp/apps/Apps.h"
 #include "displayapp/Controllers.h"
 #include "Symbols.h"
@@ -20,7 +21,9 @@ namespace Pinetime {
 
       class Weather : public Screen {
       public:
-        Weather(Controllers::Settings& settingsController, Controllers::SimpleWeatherService& weatherService);
+        Weather(Controllers::Settings& settingsController,
+                Controllers::SimpleWeatherService& weatherService,
+                Controllers::DateTime& dateTimeController);
         ~Weather() override;
 
         void Refresh() override;
@@ -28,6 +31,7 @@ namespace Pinetime {
       private:
         Controllers::Settings& settingsController;
         Controllers::SimpleWeatherService& weatherService;
+        Controllers::DateTime& dateTimeController;
 
         Utility::DirtyValue<std::optional<Controllers::SimpleWeatherService::CurrentWeather>> currentWeather {};
         Utility::DirtyValue<std::optional<Controllers::SimpleWeatherService::Forecast>> currentForecast {};
@@ -35,6 +39,7 @@ namespace Pinetime {
         lv_obj_t* icon;
         lv_obj_t* condition;
         lv_obj_t* temperature;
+        lv_obj_t* lastUpdated;
         lv_obj_t* minTemperature;
         lv_obj_t* maxTemperature;
         lv_obj_t* forecast;
@@ -49,7 +54,7 @@ namespace Pinetime {
       static constexpr const char* icon = Screens::Symbols::cloudSunRain;
 
       static Screens::Screen* Create(AppControllers& controllers) {
-        return new Screens::Weather(controllers.settingsController, *controllers.weatherController);
+        return new Screens::Weather(controllers.settingsController, *controllers.weatherController, controllers.dateTimeController);
       };
     };
   }


### PR DESCRIPTION
Provides the time since the last weather update, incrementing the duration from seconds to minutes at 60 seconds, and minutes to hours at 3600 seconds. This changeset is from https://github.com/InfiniTimeOrg/InfiniTime/pull/2242.